### PR TITLE
Fix missing include

### DIFF
--- a/lib/connection/include/connection/connection.hpp
+++ b/lib/connection/include/connection/connection.hpp
@@ -5,6 +5,7 @@
 
 #include <vector>
 #include <cstdint>
+#include <string>
 
 namespace everest { namespace connection {
     class Connection {


### PR DESCRIPTION
I am using a fairly recent compiler (gcc-c++ rev 11.2.1 20211124) and upon compilation of the everest-core project (which includes this module) I get an error `field ‘address’ has incomplete type std::string`. 

Adding the standard string header resolves this error. 

This bugfix does just that.