### PR TITLE
Change "connection" library to "modbus_connection"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ target_include_directories(modbus
 # packaging
 if (MODBUS_INSTALL)
     install(
-        TARGETS modbus connection
+        TARGETS modbus modbus_connection
         EXPORT modbus-targets
     )
 

--- a/lib/connection/CMakeLists.txt
+++ b/lib/connection/CMakeLists.txt
@@ -1,7 +1,7 @@
-add_library(connection)
-add_library(modbus::connection ALIAS connection)
-set_target_properties(connection PROPERTIES OUTPUT_NAME modbus_connection)
-target_sources(connection
+add_library(modbus_connection)
+add_library(modbus::connection ALIAS modbus_connection)
+set_target_properties(modbus_connection PROPERTIES OUTPUT_NAME modbus_connection)
+target_sources(modbus_connection
     PRIVATE
         src/rtu.cpp
         src/serial_connection_helper.cpp
@@ -10,11 +10,11 @@ target_sources(connection
         src/utils.cpp
 )
 
-target_include_directories(connection
+target_include_directories(modbus_connection
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
 )
 
-target_link_libraries(connection
+target_link_libraries(modbus_connection
     PRIVATE everest::log
 )


### PR DESCRIPTION
Otherwise this can collide with the PalSigslot library example "connection": https://github.com/palacaze/sigslot/tree/master/example
With the following error:
[...]/libmodbus/lib/connection/CMakeLists.txt:1 (add_library):
  add_library cannot create target "connection" because another target with
  the same name already exists.  The existing target is an executable created
  in source directory
  "[...]/sigslot/example".
  See documentation for policy CMP0002 for more details.

Signed-off-by: Kai-Uwe Hermann <kai-uwe.hermann@pionix.de>