### PR TITLE
Check also for actual value of _HAVE_STRUCT_TERMIOS_C_{I,O}SPEED

### DIFF
--- a/lib/connection/src/serial_connection_helper.cpp
+++ b/lib/connection/src/serial_connection_helper.cpp
@@ -31,10 +31,10 @@ void configure_device(int serial_port_fd, termios* tty);
 
 bool operator==(const termios& lhs, const termios& rhs) {
     return
-#ifdef _HAVE_STRUCT_TERMIOS_C_ISPEED
+#if defined(_HAVE_STRUCT_TERMIOS_C_ISPEED) && _HAVE_STRUCT_TERMIOS_C_ISPEED
         (lhs.c_ispeed == rhs.c_ispeed) and
 #endif
-#ifdef _HAVE_STRUCT_TERMIOS_C_OSPEED
+#if defined(_HAVE_STRUCT_TERMIOS_C_OSPEED) && _HAVE_STRUCT_TERMIOS_C_OSPEED
         (lhs.c_ospeed == rhs.c_ospeed) and
 #endif
         (lhs.c_cflag == rhs.c_cflag) and (lhs.c_iflag == rhs.c_iflag) and (lhs.c_lflag == rhs.c_lflag) and


### PR DESCRIPTION
Since glibc 2.29 just checking for existance of the mentioned defines is not sufficient for some platforms, e.g. mipsel.

For reference, see also
https://sourceware.org/git/?p=glibc.git;a=commit;h=e5a50db36eaa6e8c6427b3a971563240b633ca85